### PR TITLE
[FEAT]: 메인 페이지 음식 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/beginvegan/domain/food/application/FoodService.java
+++ b/src/main/java/com/beginvegan/domain/food/application/FoodService.java
@@ -1,0 +1,36 @@
+package com.beginvegan.domain.food.application;
+
+import com.beginvegan.domain.food.domain.Food;
+import com.beginvegan.domain.food.domain.repository.FoodRepository;
+import com.beginvegan.domain.food.dto.FoodListRes;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class FoodService {
+
+    private final FoodRepository foodRepository;
+
+    public ResponseEntity<?> findAllFoods() {
+        List<Food> foods = foodRepository.findAll();
+        List<FoodListRes> foodList = new ArrayList<>();
+
+        for (Food food : foods) {
+            FoodListRes foodListRes = FoodListRes.builder()
+                    .id(food.getId())
+                    .name(food.getName())
+                    .veganType(food.getVeganType())
+                    .description(food.getDescription())
+                    .build();
+            foodList.add(foodListRes);
+        }
+
+        return ResponseEntity.ok(foodList);
+    }
+
+}

--- a/src/main/java/com/beginvegan/domain/food/dto/FoodListRes.java
+++ b/src/main/java/com/beginvegan/domain/food/dto/FoodListRes.java
@@ -1,0 +1,25 @@
+package com.beginvegan.domain.food.dto;
+
+import com.beginvegan.domain.user.domain.VeganType;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+public class FoodListRes {
+
+    private Long id;
+
+    private String name;
+
+    private VeganType veganType;
+
+    private String description;
+
+    @Builder
+    public FoodListRes(Long id, String name, VeganType veganType, String description) {
+        this.id = id;
+        this.name = name;
+        this.veganType = veganType;
+        this.description = description;
+    }
+}

--- a/src/main/java/com/beginvegan/domain/food/presentation/FoodController.java
+++ b/src/main/java/com/beginvegan/domain/food/presentation/FoodController.java
@@ -1,0 +1,36 @@
+package com.beginvegan.domain.food.presentation;
+
+import com.beginvegan.domain.food.application.FoodService;
+import com.beginvegan.domain.food.dto.FoodListRes;
+import com.beginvegan.global.payload.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Foods", description = "Foods API")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/foods")
+public class FoodController {
+
+    private final FoodService foodService;
+
+    @Operation(summary = "전체 음식 목록 조회", description = "메인 페이지에서 사용할 정보를 포함한 전체 음식 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "전체 음식 목록 조회 성공", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = FoodListRes.class)) } ),
+            @ApiResponse(responseCode = "400", description = "전체 음식 목록 조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @GetMapping("/food-list")
+    public ResponseEntity<?> findAllFoods(){
+        return foodService.findAllFoods();
+        }
+
+}


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.`
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
## 작업 내용
메인 페이지에서 사용할 레시피(음식) 목록 조회 기능

## 스크린샷
<img width="343" alt="image" src="https://github.com/DEPthes/2nd-MVP-BeginVegan-Server/assets/112797234/2cef4e3c-5ac0-45e5-a730-83f1e3e28816">
여기 들어가면 좋을 것 같습니다

실행결과
![image](https://github.com/DEPthes/2nd-MVP-BeginVegan-Server/assets/112797234/59602895-7133-43e6-9358-3c04249f1864)

## 주의사항
메인 화면에서 3개만 필요로 하는데 3개만 줘야할지, 모두 줘야할지,,
요청 시 받을 값 있는지 확인 필요
@CurrentUser, UserPrinciple 사용한다면 : 레시피 조회하는데 사용자 정보가 필요한지 ?

Closes #15 