### PR TITLE
[FEAT]: 레시피 탭 레시피 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/beginvegan/domain/food/application/FoodService.java
+++ b/src/main/java/com/beginvegan/domain/food/application/FoodService.java
@@ -1,0 +1,49 @@
+package com.beginvegan.domain.food.application;
+
+import com.beginvegan.domain.food.domain.Food;
+import com.beginvegan.domain.food.domain.repository.FoodRepository;
+import com.beginvegan.domain.food.dto.FoodIngredientDto;
+import com.beginvegan.domain.food.dto.FoodRecipeListRes;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class FoodService {
+
+    private final FoodRepository foodRepository;
+
+    // 레시피 전체 조회 : 재료 포함 :: 하단 바 레시피 클릭 시 화면
+    @Transactional
+    public ResponseEntity<?> findAllFoodsWithIngredients() {
+        List<Food> foods = foodRepository.findAll();
+        List<FoodRecipeListRes> foodDtos = new ArrayList<>();
+
+        for (Food food : foods) {
+            List<FoodIngredientDto> foodIngredientDtos = food.getIngredients().stream()
+                    .map(ingredient -> FoodIngredientDto.builder()
+                            .id(ingredient.getId())
+                            .name(ingredient.getName())
+                            .build())
+                    .collect(Collectors.toList());
+
+            FoodRecipeListRes foodRecipeListRes = FoodRecipeListRes.builder()
+                    .id(food.getId())
+                    .name(food.getName())
+                    .veganType(food.getVeganType())
+                    .ingredients(foodIngredientDtos)
+                    .build();
+
+            foodDtos.add(foodRecipeListRes);
+        }
+
+        return ResponseEntity.ok(foodDtos);
+    }
+
+}

--- a/src/main/java/com/beginvegan/domain/food/dto/FoodIngredientDto.java
+++ b/src/main/java/com/beginvegan/domain/food/dto/FoodIngredientDto.java
@@ -1,0 +1,18 @@
+package com.beginvegan.domain.food.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+public class FoodIngredientDto {
+
+    private Long id;
+
+    private String name;
+
+    @Builder
+    public FoodIngredientDto(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+}

--- a/src/main/java/com/beginvegan/domain/food/dto/FoodRecipeListRes.java
+++ b/src/main/java/com/beginvegan/domain/food/dto/FoodRecipeListRes.java
@@ -1,0 +1,27 @@
+package com.beginvegan.domain.food.dto;
+
+import com.beginvegan.domain.user.domain.VeganType;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class FoodRecipeListRes {
+
+    private Long id;
+
+    private String name;
+
+    private VeganType veganType;
+
+    private List<FoodIngredientDto> ingredients;
+
+    @Builder
+    public FoodRecipeListRes(Long id, String name, VeganType veganType, List<FoodIngredientDto> ingredients) {
+        this.id = id;
+        this.name = name;
+        this.veganType = veganType;
+        this.ingredients = ingredients;
+    }
+}

--- a/src/main/java/com/beginvegan/domain/food/presentation/FoodController.java
+++ b/src/main/java/com/beginvegan/domain/food/presentation/FoodController.java
@@ -1,0 +1,35 @@
+package com.beginvegan.domain.food.presentation;
+
+import com.beginvegan.domain.food.application.FoodService;
+import com.beginvegan.domain.food.dto.FoodRecipeListRes;
+import com.beginvegan.global.payload.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Foods", description = "Foods API")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/foods")
+public class FoodController {
+
+    private final FoodService foodService;
+
+    @Operation(summary = "전체 레시피 목록 조회", description = "레시피 탭에서 사용할 정보를 포함한 전체 레시피 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "전체 레시피 목록 조회 성공", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = FoodRecipeListRes.class)) } ),
+            @ApiResponse(responseCode = "400", description = "전체 레시피 목록 조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @GetMapping("/recipe-list")
+    public ResponseEntity<?> findAllFoodsWithIngredients() {
+        return foodService.findAllFoodsWithIngredients();
+    }
+}


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.`
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
## 작업 내용
레시피 탭에 보여질 레시피 목록 조회
음식 이름, 비건 레벨, 재료들 포함

## 스크린샷
적용 화면
<img width="200" alt="image" src="https://github.com/DEPthes/2nd-MVP-BeginVegan-Server/assets/112797234/aa8f907f-626c-451d-9a1e-e4459f3e8089">

실행결과
![image](https://github.com/DEPthes/2nd-MVP-BeginVegan-Server/assets/112797234/6190a885-a7c6-475d-aacf-70adecd9d63d)


## 주의사항

Closes #17 