### PR TITLE
[FEAT]: 메인 화면 매거진 목록 중 2가지 랜덤 조회 API 구현

### DIFF
--- a/src/main/java/com/beginvegan/domain/magazine/application/MagazineService.java
+++ b/src/main/java/com/beginvegan/domain/magazine/application/MagazineService.java
@@ -1,0 +1,42 @@
+package com.beginvegan.domain.magazine.application;
+
+import com.beginvegan.domain.magazine.domain.Magazine;
+import com.beginvegan.domain.magazine.domain.repository.MagazineRepository;
+import com.beginvegan.domain.magazine.dto.response.MagazineListRes;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@RequiredArgsConstructor
+@Service
+public class MagazineService {
+
+    private final MagazineRepository magazineRepository;
+
+    // 2가지 매거진 랜덤 조회 : 메인 페이지
+    public ResponseEntity<?> findTwoMagazines() {
+        List<Magazine> magazines = magazineRepository.findAll();
+        List<MagazineListRes> magazineList = new ArrayList<MagazineListRes>();
+
+        // 랜덤 수 2개 추리기
+        Set<Integer> randomNum = new HashSet<>();
+        while(randomNum.size() < 2){
+            randomNum.add((int)(Math.random() * magazines.size()));
+        }
+
+        Iterator<Integer> iter = randomNum.iterator();
+        while(iter.hasNext()){
+            int num = iter.next();
+            MagazineListRes magazineListRes = MagazineListRes.builder()
+                    .id(magazines.get(num).getId())
+                    .title(magazines.get(num).getTitle())
+                    .editor(magazines.get(num).getEditor())
+                    .build();
+            magazineList.add(magazineListRes);
+        }
+
+        return ResponseEntity.ok(magazineList);
+    }
+}

--- a/src/main/java/com/beginvegan/domain/magazine/domain/repository/MagazineRepository.java
+++ b/src/main/java/com/beginvegan/domain/magazine/domain/repository/MagazineRepository.java
@@ -2,6 +2,8 @@ package com.beginvegan.domain.magazine.domain.repository;
 
 import com.beginvegan.domain.magazine.domain.Magazine;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface MagazineRepository extends JpaRepository<Magazine, Long> {
 }

--- a/src/main/java/com/beginvegan/domain/magazine/dto/response/MagazineListRes.java
+++ b/src/main/java/com/beginvegan/domain/magazine/dto/response/MagazineListRes.java
@@ -1,0 +1,21 @@
+package com.beginvegan.domain.magazine.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+public class MagazineListRes {
+
+    private Long id;
+
+    private String title;
+
+    private String editor;
+
+    @Builder
+    public MagazineListRes(Long id, String title, String editor) {
+        this.id = id;
+        this.title = title;
+        this.editor = editor;
+    }
+}

--- a/src/main/java/com/beginvegan/domain/magazine/presentation/MagazineController.java
+++ b/src/main/java/com/beginvegan/domain/magazine/presentation/MagazineController.java
@@ -1,0 +1,36 @@
+package com.beginvegan.domain.magazine.presentation;
+
+import com.beginvegan.domain.magazine.application.MagazineService;
+import com.beginvegan.domain.magazine.dto.response.MagazineListRes;
+import com.beginvegan.global.payload.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Magazines", description = "Magazines API")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/magazines")
+public class MagazineController {
+
+    private final MagazineService magazineService;
+
+    // 랜덤 매거진 2가지 조회
+    @Operation(summary = "2가지 매거진 목록 조회", description = "2가지 매거진 목록 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "2가지 매거진 목록 조회 성공", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = MagazineListRes.class)) } ),
+            @ApiResponse(responseCode = "400", description = "2가지 매거진 목록 조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @GetMapping("/random-megazine-list")
+    public ResponseEntity<?> findTwoMagazines(){
+        return magazineService.findTwoMagazines();
+    }
+}


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.`
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
## 작업 내용
메인 페이지에서 사용할 매거진 목록 조회 기능
: 2가지 랜덤 조회

## 스크린샷
적용 화면
<img width="222" alt="image" src="https://github.com/DEPthes/2nd-MVP-BeginVegan-Server/assets/112797234/9b011dda-326e-4715-b0c0-87084de83655">

실행 결과
<img width="1240" alt="image" src="https://github.com/DEPthes/2nd-MVP-BeginVegan-Server/assets/112797234/3abca7bb-a508-430c-bea6-764bc9a87209">

랜덤 확인
<img width="1238" alt="image" src="https://github.com/DEPthes/2nd-MVP-BeginVegan-Server/assets/112797234/ca98e36d-6829-46d5-a017-d6f542c5dc6a">

## 주의사항

Closes #23 