### PR TITLE
[FEAT]: 메인 화면 매거진 목록 중 2가지 랜덤 조회 API 구현

### DIFF
--- a/src/main/java/com/beginvegan/domain/magazine/application/MagazineService.java
+++ b/src/main/java/com/beginvegan/domain/magazine/application/MagazineService.java
@@ -1,6 +1,7 @@
 package com.beginvegan.domain.magazine.application;
 
 import com.beginvegan.domain.magazine.domain.Magazine;
+import com.beginvegan.domain.magazine.domain.MagazineType;
 import com.beginvegan.domain.magazine.domain.repository.MagazineRepository;
 import com.beginvegan.domain.magazine.dto.response.MagazineListRes;
 import lombok.RequiredArgsConstructor;
@@ -18,24 +19,33 @@ public class MagazineService {
     // 2가지 매거진 랜덤 조회 : 메인 페이지
     public ResponseEntity<?> findTwoMagazines() {
         List<Magazine> magazines = magazineRepository.findAll();
-        List<MagazineListRes> magazineList = new ArrayList<MagazineListRes>();
+        List<Magazine> magazines_meaning = magazineRepository.findAllByMagazineType(MagazineType.VEGAN_MEANING);
+        List<Magazine> magazines_type = magazineRepository.findAllByMagazineType(MagazineType.VEGAN_TYPE);
 
-        // 랜덤 수 2개 추리기
-        Set<Integer> randomNum = new HashSet<>();
-        while(randomNum.size() < 2){
-            randomNum.add((int)(Math.random() * magazines.size()));
-        }
+        // 랜덤 수 1개씩 추리기 :: 비건 정의 1, 비건 종류 1
+        int randomNum_meaning = (int)(Math.random() * magazines_meaning.size());
+        int randomNum_type = (int)(Math.random() * magazines_type.size());
 
-        Iterator<Integer> iter = randomNum.iterator();
-        while(iter.hasNext()){
-            int num = iter.next();
-            MagazineListRes magazineListRes = MagazineListRes.builder()
-                    .id(magazines.get(num).getId())
-                    .title(magazines.get(num).getTitle())
-                    .editor(magazines.get(num).getEditor())
-                    .build();
-            magazineList.add(magazineListRes);
-        }
+        Magazine magazine_meaning = magazines_meaning.get(randomNum_meaning);
+        Magazine magazine_type = magazines_type.get(randomNum_type);
+
+        List<MagazineListRes> magazineList = new ArrayList<>();
+
+        MagazineListRes magazineListRes = MagazineListRes.builder()
+                .id(magazine_meaning.getId())
+                .title(magazine_meaning.getTitle())
+                .editor(magazine_meaning.getEditor())
+                .magazineType(magazine_meaning.getMagazineType())
+                .build();
+        magazineList.add(magazineListRes);
+
+        magazineListRes = MagazineListRes.builder()
+                .id(magazine_type.getId())
+                .title(magazine_type.getTitle())
+                .editor(magazine_type.getEditor())
+                .magazineType(magazine_type.getMagazineType())
+                .build();
+        magazineList.add(magazineListRes);
 
         return ResponseEntity.ok(magazineList);
     }

--- a/src/main/java/com/beginvegan/domain/magazine/application/MagazineService.java
+++ b/src/main/java/com/beginvegan/domain/magazine/application/MagazineService.java
@@ -1,0 +1,42 @@
+package com.beginvegan.domain.magazine.application;
+
+import com.beginvegan.domain.magazine.domain.Magazine;
+import com.beginvegan.domain.magazine.domain.repository.MagazineRepository;
+import com.beginvegan.domain.magazine.dto.response.MagazineListRes;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@RequiredArgsConstructor
+@Service
+public class MagazineService {
+
+    private final MagazineRepository magazineRepository;
+
+    // 2가지 매거진 랜덤 조회 : 메인 페이지
+    public ResponseEntity<?> findTwoMagazines() {
+        List<Magazine> magazines = magazineRepository.findAll();
+        List<MagazineListRes> magazineList = new ArrayList<MagazineListRes>();
+
+        // 랜덤 수 2개 추리기
+        Set<Integer> randomNum = new HashSet<>();
+        while(randomNum.size() < 2){
+            randomNum.add((int)(Math.random() * magazines.size()));
+        }
+
+        Iterator<Integer> iter = randomNum.iterator();
+        while(iter.hasNext()){
+            int num = iter.next();
+            MagazineListRes magazineListRes = MagazineListRes.builder()
+                    .id(magazines.get(num).getId())
+                    .title(magazines.get(num).getTitle())
+                    .editor(magazines.get(num).getEditor())
+                    .build();
+            magazineList.add(magazineListRes);
+        }
+
+        return ResponseEntity.ok(magazineList);
+    }
+}

--- a/src/main/java/com/beginvegan/domain/magazine/domain/Magazine.java
+++ b/src/main/java/com/beginvegan/domain/magazine/domain/Magazine.java
@@ -23,14 +23,17 @@ public class Magazine extends BaseEntity {
 
     private String editor;
 
+    private MagazineType magazineType;
+
     @OneToMany(mappedBy = "magazine")
     private List<Block> magazineBlocks = new ArrayList<>();
 
     @Builder
-    public Magazine(Long id, String title, String editor, List<Block> magazineBlocks) {
+    public Magazine(Long id, String title, String editor, MagazineType magazineType, List<Block> magazineBlocks) {
         this.id = id;
         this.title = title;
         this.editor = editor;
+        this.magazineType = magazineType;
         this.magazineBlocks = magazineBlocks;
     }
 

--- a/src/main/java/com/beginvegan/domain/magazine/domain/MagazineType.java
+++ b/src/main/java/com/beginvegan/domain/magazine/domain/MagazineType.java
@@ -1,0 +1,5 @@
+package com.beginvegan.domain.magazine.domain;
+
+public enum MagazineType {
+    VEGAN_MEANING, VEGAN_TYPE;
+}

--- a/src/main/java/com/beginvegan/domain/magazine/domain/repository/MagazineRepository.java
+++ b/src/main/java/com/beginvegan/domain/magazine/domain/repository/MagazineRepository.java
@@ -1,9 +1,15 @@
 package com.beginvegan.domain.magazine.domain.repository;
 
 import com.beginvegan.domain.magazine.domain.Magazine;
+import com.beginvegan.domain.magazine.domain.MagazineType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface MagazineRepository extends JpaRepository<Magazine, Long> {
+
+    List<Magazine> findAllByMagazineType(MagazineType magazineType);
+
 }

--- a/src/main/java/com/beginvegan/domain/magazine/domain/repository/MagazineRepository.java
+++ b/src/main/java/com/beginvegan/domain/magazine/domain/repository/MagazineRepository.java
@@ -2,6 +2,8 @@ package com.beginvegan.domain.magazine.domain.repository;
 
 import com.beginvegan.domain.magazine.domain.Magazine;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface MagazineRepository extends JpaRepository<Magazine, Long> {
 }

--- a/src/main/java/com/beginvegan/domain/magazine/dto/response/MagazineListRes.java
+++ b/src/main/java/com/beginvegan/domain/magazine/dto/response/MagazineListRes.java
@@ -1,0 +1,21 @@
+package com.beginvegan.domain.magazine.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+public class MagazineListRes {
+
+    private Long id;
+
+    private String title;
+
+    private String editor;
+
+    @Builder
+    public MagazineListRes(Long id, String title, String editor) {
+        this.id = id;
+        this.title = title;
+        this.editor = editor;
+    }
+}

--- a/src/main/java/com/beginvegan/domain/magazine/dto/response/MagazineListRes.java
+++ b/src/main/java/com/beginvegan/domain/magazine/dto/response/MagazineListRes.java
@@ -1,5 +1,6 @@
 package com.beginvegan.domain.magazine.dto.response;
 
+import com.beginvegan.domain.magazine.domain.MagazineType;
 import lombok.Builder;
 import lombok.Data;
 
@@ -12,10 +13,13 @@ public class MagazineListRes {
 
     private String editor;
 
+    private MagazineType magazineType;
+
     @Builder
-    public MagazineListRes(Long id, String title, String editor) {
+    public MagazineListRes(Long id, String title, String editor, MagazineType magazineType) {
         this.id = id;
         this.title = title;
         this.editor = editor;
+        this.magazineType = magazineType;
     }
 }

--- a/src/main/java/com/beginvegan/domain/magazine/presentation/MagazineController.java
+++ b/src/main/java/com/beginvegan/domain/magazine/presentation/MagazineController.java
@@ -1,0 +1,36 @@
+package com.beginvegan.domain.magazine.presentation;
+
+import com.beginvegan.domain.magazine.application.MagazineService;
+import com.beginvegan.domain.magazine.dto.response.MagazineListRes;
+import com.beginvegan.global.payload.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Magazines", description = "Magazines API")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/magazines")
+public class MagazineController {
+
+    private final MagazineService magazineService;
+
+    // 랜덤 매거진 2가지 조회
+    @Operation(summary = "2가지 매거진 목록 조회", description = "2가지 매거진 목록 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "2가지 매거진 목록 조회 성공", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = MagazineListRes.class)) } ),
+            @ApiResponse(responseCode = "400", description = "2가지 매거진 목록 조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @GetMapping("/random-megazine-list")
+    public ResponseEntity<?> findTwoMagazines(){
+        return magazineService.findTwoMagazines();
+    }
+}


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.`
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
## 작업 내용
메인 페이지에서 사용할 매거진 목록 조회 기능
: 매거진은 비건 정의 / 비건 종류에 대한 매거진으로 구분된다.
따라서 비건 정의 매거진 1, 비건 종류 매거진 1을 랜덤으로 구성하여 메인 페이지 배너에 띄워질 수 있다.

## 스크린샷
적용 화면
![image](https://github.com/DEPthes/2nd-MVP-BeginVegan-Server/assets/112797234/630cde1e-027e-4166-9579-a6ac22e0228a)

실행 결과
<img width="1350" alt="image" src="https://github.com/DEPthes/2nd-MVP-BeginVegan-Server/assets/112797234/8165263b-f8fa-4f72-99ec-1984c5ca6559">

랜덤 호출 확인
<img width="1355" alt="image" src="https://github.com/DEPthes/2nd-MVP-BeginVegan-Server/assets/112797234/29b95313-f8b6-4d69-8ea4-45296caec493">

## 주의사항
매거진 종류 구분을 위하여 MegazineType enum 추가했습니다.

Closes #23 